### PR TITLE
Allow simpler game scuttling

### DIFF
--- a/PS4Bot.py
+++ b/PS4Bot.py
@@ -20,6 +20,9 @@ def replace_dict(str, dict):
         str = str.replace("%" + k, dict[k])
     return str
 
+def plural(int):
+    return "" if int == 1 else "s"
+
 class PS4Bot(Bot):
     def __init__(self, slackconnection, botname):
         Bot.__init__(self, slackconnection, botname)
@@ -209,7 +212,7 @@ class PS4Bot(Bot):
 
         self.send_message("{0} game{1}:\n{2}".format(
             len(self.games),
-            "" if len(self.games) == 1 else "s",
+            plural(self.games),
             "\n".join([g.pretty() for g in self.chronological_games()])
         ))
 

--- a/PS4Bot.spec.py
+++ b/PS4Bot.spec.py
@@ -94,6 +94,9 @@ class TestGame(unittest.TestCase):
 def noop(*args):
 	pass
 
+def update_message_stub(self, text, original_message):
+	pass
+
 class DummyChannel:
 	def __init__(self, name):
 		self.name = name
@@ -105,12 +108,18 @@ class TestPS4Bot(unittest.TestCase):
 		PS4Bot.save = noop
 		PS4Bot.load = noop
 		PS4Bot.lookup_user = lambda self, a: a
+		PS4Bot.update_message = update_message_stub
 
 	def create_ps4bot(self):
 		self.messages = []
 
+		def send_message_stub(msg):
+			self.messages.append(msg)
+			dummy_when = today_at(11, 43)
+			return SlackMessage(msg, "user", None, None, None, dummy_when, None)
+
 		ps4bot = PS4Bot(None, "ps4bot")
-		ps4bot.send_message = lambda msg: self.messages.append(msg)
+		ps4bot.send_message = send_message_stub
 		return ps4bot
 
 	def test_ps4bot_game_overlap_after(self):
@@ -141,5 +150,33 @@ class TestPS4Bot(unittest.TestCase):
 
 		self.assertEqual(len(self.messages), 1)
 		self.assertEqual(self.messages[0], ":warning: there's already a games game at 14:30: test game. rip :candle:")
+
+	def test_ps4bot_scuttle_via_two_times(self):
+		dummychannel = DummyChannel("games")
+
+		ps4bot = self.create_ps4bot()
+		ps4bot.handle_message(SlackMessage("ps4bot test game at 1", "user", dummychannel, None, None, None, None))
+
+		self.assertEqual(len(self.messages), 1)
+		self.messages = []
+
+		ps4bot.handle_message(SlackMessage("ps4bot scuttle 1pm to 3", "user", dummychannel, None, None, None, None))
+
+		self.assertEqual(len(self.messages), 1)
+		self.assertEqual(self.messages[0], ":alarm_clock: test game moved from 13:00 to 15:00 by <@user>")
+
+	def test_ps4bot_scuttle_via_single_time(self):
+		dummychannel = DummyChannel("games")
+
+		ps4bot = self.create_ps4bot()
+		ps4bot.handle_message(SlackMessage("ps4bot test game at 1", "user", dummychannel, None, None, None, None))
+
+		self.assertEqual(len(self.messages), 1)
+		self.messages = []
+
+		ps4bot.handle_message(SlackMessage("ps4bot scuttle 3", "user", dummychannel, None, None, None, None))
+
+		self.assertEqual(len(self.messages), 1)
+		self.assertEqual(self.messages[0], ":alarm_clock: test game moved from 13:00 to 15:00 by <@user>")
 
 unittest.main()

--- a/ps4-todo.txt
+++ b/ps4-todo.txt
@@ -6,7 +6,6 @@ Usage:
 
 Messaging:
 	[large] Update all "ps4bot games" messages when a game changes
-	[medium] Handle "ps4bot scuttle 3pm" - look for games by said user, if there's only one, move it to <time>
 	[medium] If a game isn't full 10 minutes beforehand, send a "@here" requesting additional players
 	[small] Allow "ps4" prefix
 	[small] Move tips category into others


### PR DESCRIPTION
Users can now scuttle their existing game with `ps4bot scuttle 3pm`, if they have only one game. If they've created multiple games, they'd still have to `ps4bot scuttle 2pm to 3pm`.