### PR TITLE
Expose k factor and history as args and add min games sort to leaderboard

### DIFF
--- a/PS4Bot.py
+++ b/PS4Bot.py
@@ -753,12 +753,12 @@ class PS4Bot(Bot):
             )
 
             if history_length:
-                ranking_values = map(lambda ranking: [ranking.id, ranking.games_played, ranking.ranking, ranking.getHistory(history_length)], rankings.values())
-                ranking_values.sort(key=lambda x: x[2], reverse=True)
+                ranking_values = map(lambda ranking: [ranking.getName(), ranking.games_played, ranking.getFormattedRanking(), ranking.getHistory(history_length)], rankings.values())
+                ranking_values.sort(key=lambda x: (x[1] > 10,  x[2]), reverse=True)
                 table = generate_table(['Player', 'Games Played', 'Ranking', 'Form'], ranking_values)
             else: 
-                ranking_values = map(lambda ranking: [ranking.id, ranking.games_played, ranking.ranking], rankings.values())
-                ranking_values.sort(key=lambda x: x[2], reverse=True)
+                ranking_values = map(lambda ranking: [ranking.getName(), ranking.games_played, ranking.getFormattedRanking()], rankings.values())
+                ranking_values.sort(key=lambda x: (x[1] > 10, x[2]), reverse=True)
                 table = generate_table(['Player', 'Games Played', 'Ranking'], ranking_values)
 
             self.send_message(table)

--- a/PS4Bot.py
+++ b/PS4Bot.py
@@ -729,6 +729,7 @@ class PS4Bot(Bot):
         anchor_message = True
         channel_name = None
         year = None
+        k_factor = None
 
         if len(rest):
             parsed = parse_stats_request(rest)
@@ -736,7 +737,7 @@ class PS4Bot(Bot):
                 self.send_message(":warning: ere {}: \"{} [year] [channel]\"".format(
                     type, format_user(message.user)))
                 return
-            channel_name, year = parsed
+            channel_name, year, k_factor = parsed
             anchor_message = (channel_name is None or channel_name == message.channel.name) \
                     and (year is None or year.year == datetime.date.today().year)
 
@@ -744,7 +745,7 @@ class PS4Bot(Bot):
             channel_name = message.channel.name
 
         if type == StatRequest.elo:
-            rankings = self.history.summary_elo(channel_name, year = year)
+            rankings = self.history.summary_elo(channel_name, year = year, k_factor = k_factor)
             ranking_values = map(lambda ranking: [ranking.id, ranking.games_played, ranking.ranking], rankings.values())
             ranking_values.sort(key=lambda x: x[2], reverse=True)
 

--- a/PS4Elo.py
+++ b/PS4Elo.py
@@ -2,15 +2,54 @@ initial_ranking = 1500
 default_k_factor = 20
 scrub_modifier = 1.1
 
+
 class Result:
     win = 1
     loss = 0
+
 
 class Player:
     def __init__(self, id, ranking=initial_ranking):
         self.id = id
         self.ranking = ranking
         self.games_played = 0
+        self.historical_ranking = []
+
+    def getHistory(self, history_length):
+
+        history = ''
+
+        if not history_length:
+            return None
+
+        results = []
+        previous_rank = None
+
+        relevant_history = self.historical_ranking[-(history_length + 1):]
+        for rank in relevant_history:
+            if not previous_rank:
+                if (len(relevant_history) != history_length + 1):
+                    previous_rank = HisoricalRank(initial_ranking)
+                else:
+                    previous_rank = rank
+                    continue
+            results.append(previous_rank.rank < rank.rank)
+            previous_rank = rank
+
+        history = reduce(lambda result, value: result +
+                         'W ' if value else result + 'L ', results, ' ')
+
+        return history
+
+
+class HisoricalRank:
+
+    def __init__(self, rank, team = None, delta = None, scrub_modifier = None):
+        self.rank = rank
+        self.team = team
+        self.delta = delta
+        self.scrub_modifier = scrub_modifier
+
 
 class Game:
     def __init__(self, teams, winning_team_index, scrubs):
@@ -21,9 +60,11 @@ class Game:
     def player_ids(self):
         return reduce(list.__add__, self.teams)
 
+
 def expected_score(ranking, other_ranking):
     diff = 10 ** ((other_ranking - ranking) / float(400))
     return float(1) / (1 + diff)
+
 
 def ranking_delta(ranking, other_ranking, result, k_factor):
 
@@ -42,20 +83,24 @@ def ranking_delta(ranking, other_ranking, result, k_factor):
 
     return initial_delta
 
+
 def combined_ranking_for_team(team, players):
     if len(team) == 0:
         return 0
     return sum(map(lambda player_id: player_from_id(players, player_id).ranking, team)) / len(team)
 
+
 def other_team_ranking(teams, players):
     merged_teams = reduce(list.__add__, teams)
     return combined_ranking_for_team(merged_teams, players)
+
 
 def ranking_delta_for_game(game, players, k_factor):
     teams = game.teams
     winning_team_index = game.winning_team_index
 
-    team_rankings = map(lambda team: combined_ranking_for_team(team, players), teams)
+    team_rankings = map(
+        lambda team: combined_ranking_for_team(team, players), teams)
 
     players_delta = {}
     for index, team in enumerate(teams):
@@ -63,7 +108,8 @@ def ranking_delta_for_game(game, players, k_factor):
             if index == winning_team_index:
                 team_result = Result.win
 
-                other_teams = teams[:winning_team_index] + teams[winning_team_index+1 :]
+                other_teams = teams[:winning_team_index] + \
+                    teams[winning_team_index+1:]
 
                 other_team_rank = other_team_ranking(other_teams, players)
             else:
@@ -71,20 +117,24 @@ def ranking_delta_for_game(game, players, k_factor):
                 other_team_rank = team_rankings[winning_team_index]
 
             player_ranking = player_from_id(players, player_id).ranking
-            rank_delta = ranking_delta(player_ranking, other_team_rank, team_result, k_factor)
+            rank_delta = ranking_delta(
+                player_ranking, other_team_rank, team_result, k_factor)
             players_delta[player_id] = rank_delta
 
     return players_delta
+
 
 def calculate_scrub_modifier(player, game):
     if player.id in game.scrubs:
         return scrub_modifier ** game.scrubs[player.id]
     return 1
 
+
 def player_from_id(players, player_id):
     if player_id in players:
         return players[player_id]
     return Player(player_id)
+
 
 def player_in_winning_team(player, game):
     team_index = -1
@@ -95,7 +145,9 @@ def player_in_winning_team(player, game):
 
     return team_index == game.winning_team_index
 
+
 def calculate_rankings(games, k_factor):
+
     players = {}
 
     for game in games:
@@ -104,7 +156,8 @@ def calculate_rankings(games, k_factor):
             if player_id not in players:
                 players[player_id] = player_from_id(players, player_id)
 
-        individual_ranking_delta = ranking_delta_for_game(game, players, k_factor)
+        individual_ranking_delta = ranking_delta_for_game(
+            game, players, k_factor)
 
         for team in game.teams:
             for player in map(lambda player_id: player_from_id(players, player_id), team):
@@ -114,6 +167,9 @@ def calculate_rankings(games, k_factor):
                 if player_in_winning_team(player, game):
                     scrub_modifier = calculate_scrub_modifier(player, game)
 
-                player.ranking += round(individual_ranking_delta[player.id] * scrub_modifier)
+                player.ranking += round(
+                    individual_ranking_delta[player.id] * scrub_modifier)
+                player.historical_ranking.append(HisoricalRank(
+                    player.ranking, team, individual_ranking_delta, scrub_modifier))
 
     return players

--- a/PS4Elo.py
+++ b/PS4Elo.py
@@ -15,6 +15,16 @@ class Player:
         self.games_played = 0
         self.historical_ranking = []
 
+    def getName(self):
+        if (self.games_played > 10):
+            return self.id
+        return self.id + '*'
+
+    def getFormattedRanking(self):
+        if (self.games_played > 10):
+            return self.ranking
+        return str(self.ranking) + '?'
+
     def getHistory(self, history_length):
 
         history = ''

--- a/PS4Elo.spec.py
+++ b/PS4Elo.spec.py
@@ -43,7 +43,7 @@ class TestPS4Elo(unittest.TestCase):
             3: -4,
             4: -4
         }
-        self.assertDictEqual(game_rankdelta(game1, players), result1)
+        self.assertDictEqual(game_rankdelta(game1, players, None), result1)
 
         team3 = [2, 3]
         team4 = [5, 6]
@@ -55,7 +55,7 @@ class TestPS4Elo(unittest.TestCase):
             5: 19,
             6: 1
         }
-        self.assertDictEqual(game_rankdelta(game2, players), result2)
+        self.assertDictEqual(game_rankdelta(game2, players, None), result2)
 
         game3 = PS4Elo.Game(teams2, 0, {})
         result3 = {
@@ -64,7 +64,7 @@ class TestPS4Elo(unittest.TestCase):
             5: -1,
             6: -20
         }
-        self.assertDictEqual(game_rankdelta(game3, players), result3)
+        self.assertDictEqual(game_rankdelta(game3, players, None), result3)
 
     def test_ranking_delta_for_game_multi_team(self):
         game_rankdelta = PS4Elo.ranking_delta_for_game
@@ -92,7 +92,7 @@ class TestPS4Elo(unittest.TestCase):
             6:-20
         }
 
-        self.assertDictEqual(game_rankdelta(game, players), result)
+        self.assertDictEqual(game_rankdelta(game, players, None), result)
 
     def test_calculate_scrub_ranking(self):
         scrub_mod = PS4Elo.calculate_scrub_modifier
@@ -133,7 +133,7 @@ class TestPS4Elo(unittest.TestCase):
 
         games1 = [game1, game2]
 
-        result1 = calc_ranks(games1)
+        result1 = calc_ranks(games1, None)
 
         self.assertEqual(result1[1].ranking, 1499)
         self.assertEqual(result1[2].ranking, 1499)
@@ -142,7 +142,7 @@ class TestPS4Elo(unittest.TestCase):
 
         games2 = [game2, game2, game2]
 
-        result2 = calc_ranks(games2)
+        result2 = calc_ranks(games2, None)
         self.assertEqual(result2[1].ranking, 1472)
         self.assertEqual(result2[2].ranking, 1472)
         self.assertEqual(result2[3].ranking, 1528)

--- a/PS4History.py
+++ b/PS4History.py
@@ -156,7 +156,7 @@ class PS4History:
 
         return stats # { mode: { user: { [stat]: int ... }, ... } }
 
-    def summary_elo(self, channel, year = None):
+    def summary_elo(self, channel, year = None, k_factor = None):
         nextyear = calc_nextyear(year)
 
         def game_is_this_channel(game):
@@ -192,7 +192,7 @@ class PS4History:
         elo_games = map(convert_to_elo_game, elo_games)
         elo_games = filter(game_can_elo, elo_games)
 
-        rankings = PS4Elo.calculate_rankings(elo_games)
+        rankings = PS4Elo.calculate_rankings(elo_games, k_factor)
 
         return rankings
 

--- a/PS4Parsing.py
+++ b/PS4Parsing.py
@@ -68,6 +68,7 @@ def parse_stats_request(request):
     channel_name = None
     since = None
     k_factor = None
+    history_length = None
 
     parts = request.split(" ")
     for part in parts:
@@ -85,14 +86,25 @@ def parse_stats_request(request):
                     continue
                 except ValueError:
                     pass
-        elif not channel_name:
+            continue
+
+        if part.startswith("h="):
+            if not history_length:
+                try:
+                    history_length = int(part[2:])
+                    continue
+                except ValueError:
+                    pass
+            continue
+        
+        if not channel_name:
             channel_name = part
             continue
 
         # unrecognised
         return None
 
-    return channel_name, date_with_year(since) if since else None, k_factor
+    return channel_name, date_with_year(since) if since else None, k_factor, history_length
 
 def pretty_mode(mode):
     if mode == "compet":

--- a/PS4Parsing.py
+++ b/PS4Parsing.py
@@ -67,6 +67,7 @@ def maybe_parse_time(s):
 def parse_stats_request(request):
     channel_name = None
     since = None
+    k_factor = None
 
     parts = request.split(" ")
     for part in parts:
@@ -77,14 +78,21 @@ def parse_stats_request(request):
             except ValueError:
                 pass
 
-        if not channel_name:
+        if part.startswith("k="):
+            if not k_factor:
+                try:
+                    k_factor = int(part[2:])
+                    continue
+                except ValueError:
+                    pass
+        elif not channel_name:
             channel_name = part
             continue
 
         # unrecognised
         return None
 
-    return channel_name, date_with_year(since) if since else None
+    return channel_name, date_with_year(since) if since else None, k_factor
 
 def pretty_mode(mode):
     if mode == "compet":


### PR DESCRIPTION
user can now change k factor of results with arg 'k=int' to temp tweak the leaderboard https://en.wikipedia.org/wiki/Elo_rating_system#Most_accurate_K-factor

adding 'h=int' adds the users history (form) as a column in the leaderboard

also added provisional ratings for players with less than 10 games but am not changing the scoring for provisional players yet as we will never have enough data https://en.wikipedia.org/wiki/Elo_rating_system#Theory

